### PR TITLE
docs: add crates.io reference to installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ You don’t have to fuss with that pesky `package.json` file in your projects an
 
 ## Installation
 
+Samoyed is published on [crates.io](https://crates.io/crates/samoyed):
+
 ```bash
 cargo install samoyed
 ```


### PR DESCRIPTION
## Summary

- Add explicit reference to crates.io in the installation section of README.md
- Provides users with clear context that Samoyed is officially published on crates.io

## Changes

- Updated Installation section to mention publication on crates.io with link
- No functional changes to the application

🤖 Generated with [Claude Code](https://claude.ai/code)