### PR TITLE
🔧 Fix GPG fingerprint verification robustness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,9 +442,17 @@ jobs:
           echo "🔍 Verifying exported public key..."
           gpg --import --import-options show-only --with-fingerprint samoyed-release-public.key
 
-          # Verify fingerprint matches expected value
-          if ! gpg --import --import-options show-only --with-fingerprint samoyed-release-public.key | grep -q "${{ vars.GPG_FINGERPRINT }}"; then
+          # Verify fingerprint matches expected value (normalize spacing)
+          ACTUAL_FINGERPRINT=$(gpg --import --import-options show-only --with-fingerprint samoyed-release-public.key | grep -E '^\s+[0-9A-F]{4} [0-9A-F]{4}' | tr -s ' ' | xargs)
+          EXPECTED_FINGERPRINT="${{ vars.GPG_FINGERPRINT }}"
+          
+          echo "Expected: ${EXPECTED_FINGERPRINT}"
+          echo "Actual:   ${ACTUAL_FINGERPRINT}"
+          
+          if [[ "${ACTUAL_FINGERPRINT}" != "${EXPECTED_FINGERPRINT}" ]]; then
             echo "❌ Public key fingerprint verification failed"
+            echo "Expected: ${EXPECTED_FINGERPRINT}"
+            echo "Actual:   ${ACTUAL_FINGERPRINT}"
             exit 1
           fi
           echo "✅ Public key exported and verified"


### PR DESCRIPTION
## Summary

Fixes GPG fingerprint verification failure in the release workflow by improving spacing normalization.

☑ Normalize spacing in fingerprint comparison to handle GPG's variable output format
☑ Add debug output to show expected vs actual fingerprints for easier troubleshooting
☑ Use `tr -s` and `xargs` to normalize whitespace consistently

## Problem

The release workflow was failing during GPG fingerprint verification because:
- GPG outputs fingerprints with variable spacing (double spaces in some positions)
- The workflow was doing exact string matching which failed due to spacing differences
- Error: `❌ Public key fingerprint verification failed`

**Expected:** `02D1 B70C F6D8 41EE E687 6E13 F7A6 F833 1CBB C51F`
**Actual:**   `02D1 B70C F6D8 41EE E687  6E13 F7A6 F833 1CBB C51F` (note double space)

## Solution

- Extract fingerprint using regex pattern matching
- Normalize spacing with `tr -s ' '` and `xargs` 
- Add debug output for easier troubleshooting
- More robust comparison logic

## Testing

- [x] Workflow builds successfully
- [x] All tests pass
- [ ] Release workflow GPG verification (will test after merge)

## Type of Change

☑ Bug fix (non-breaking change which fixes an issue)
☐ New feature (non-breaking change which adds functionality)
☐ Breaking change (fix or feature that would cause existing functionality to not work as expected)
☐ Documentation update
☐ Chore/cleanup (non-breaking change that doesn't add features or fix bugs)