### PR TITLE
🔧 Fix GPG fingerprint verification in verify_signatures job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,9 +700,17 @@ jobs:
           # Import public key
           gpg --import samoyed-release-public.key
 
-          # Verify key fingerprint
-          if ! gpg --fingerprint ${{ vars.FULL_GPG_KEY_ID }} | grep -q "${{ vars.GPG_FINGERPRINT }}"; then
+          # Verify key fingerprint (normalize spacing)
+          ACTUAL_FINGERPRINT=$(gpg --fingerprint ${{ vars.FULL_GPG_KEY_ID }} | grep -E '^\s+[0-9A-F]{4} [0-9A-F]{4}' | tr -s ' ' | xargs)
+          EXPECTED_FINGERPRINT="${{ vars.GPG_FINGERPRINT }}"
+          
+          echo "Expected: ${EXPECTED_FINGERPRINT}"
+          echo "Actual:   ${ACTUAL_FINGERPRINT}"
+          
+          if [[ "${ACTUAL_FINGERPRINT}" != "${EXPECTED_FINGERPRINT}" ]]; then
             echo "❌ Public key fingerprint verification failed"
+            echo "Expected: ${EXPECTED_FINGERPRINT}"
+            echo "Actual:   ${ACTUAL_FINGERPRINT}"
             exit 1
           fi
           echo "✅ Public key fingerprint verified"


### PR DESCRIPTION
## Summary

Fixes the second instance of GPG fingerprint verification failure in the verify_signatures job by applying the same whitespace normalization fix.

## Problem

The verify_signatures job was failing with the same whitespace issue:
- GPG outputs fingerprints with variable spacing (double spaces in some positions)  
- The workflow was doing exact string matching which failed due to spacing differences
- Error: ❌ Public key fingerprint verification failed

## Solution

Applied the same robust fingerprint verification pattern with spacing normalization.

## Type of Change

☑ Bug fix (non-breaking change which fixes an issue)