### PR TITLE
fix: grant contents write permission to release-pr workflow

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -14,7 +14,7 @@ on:
     branches: [master]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 env:


### PR DESCRIPTION
The release-plz action needs to create branches for release PRs, which requires write access to repository contents. Changed from contents: read to contents: write to fix 403 Forbidden error when creating release PR branches.